### PR TITLE
Fix some typos in various `README.md`

### DIFF
--- a/src/exercises/concrete/parallelCollectErrors/README.md
+++ b/src/exercises/concrete/parallelCollectErrors/README.md
@@ -4,7 +4,7 @@
 
 Usually, when we have promises that are running in parallel, we use `Promise.all` to wait for the completion of all of them, however, when we do that, a single promise rejection causes the "entire process" to fail, which prevents us from reading the results of any promises that might have fulfilled.
 
-In some scenarios, this is what we want, but in others, it's useful to collect the errors/rejections so that we can either inform wha has gone wrong or even do something with these errors ourselves, like retrying the tasks that were responsible for these errors.
+In some scenarios, this is what we want, but in others, it's useful to collect the errors/rejections so that we can either inform what has gone wrong or even do something with these errors ourselves, like retrying the tasks that were responsible for these errors.
 
 In this exercise, we'll make calls to `postData` in parallel and collect the errors.
 

--- a/src/exercises/concrete/retryWithTimeout/README.md
+++ b/src/exercises/concrete/retryWithTimeout/README.md
@@ -2,7 +2,7 @@
 
 **Level: Intermediate**
 
-When retrying failed operations we usually don't want to retry them indefinitelly, so we might want to use some criteria to decide when we stop retrying.
+When retrying failed operations we usually don't want to retry them indefinitely, so we might want to use some criteria to decide when to stop retrying.
 
 In the `concrete/retry` exercise we used the amount of retries as the criteria for when to stop, but now we'll use the **elapsed time**, that is, we'll have a timeout.
 

--- a/src/exercises/concrete/serialCollectErrors/README.md
+++ b/src/exercises/concrete/serialCollectErrors/README.md
@@ -2,7 +2,7 @@
 
 **Level: Beginner**
 
-This exercise is very similar to the `concrete/serial` one, however, in this case we'll consider the possibility that calls to `postData` might fail, and when they do, we'll collect their and return them.
+This exercise is very similar to the `concrete/serial` one, however, in this case we'll consider the possibility that calls to `postData` might fail, and when they do, we'll collect their errors and return them.
 
 ## Requirements
 


### PR DESCRIPTION
### CHANGES:
- added a missing word from the exercise in `serialCollectErrors/README.md`;
- fixed a typo in  `parallelCollectErrors/README.md`;
- fixed a typo in  `retryWithTimeout/README.md`;