### PR TITLE
fix(graph:ui): reject reason with label

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ In this graph, we have task `B` which depends on `A`'s fulfillment and task `C` 
 
 This means that `B` can only start after `A` has been fulfilled and `C` can only start after `A` has been rejected.
 
-As only one of these outcomes is possible, either `B` or `C` will not be carried out.
+As only one of these outcomes is possible, either `B` or `C` will be carried out.
 
 Corresponding implementation:
 

--- a/src/lib/graphExercise/ui/src/domain/Exercise.ts
+++ b/src/lib/graphExercise/ui/src/domain/Exercise.ts
@@ -120,7 +120,7 @@ const internalCreateExercise = (params: InternalCreateExerciseParameters) => {
   };
 
   const reject = async (label: string): Promise<Exercise> => {
-    promiseManager.reject(label);
+    promiseManager.reject(label, label);
     await waitForPromises();
 
     const existingPromises = records.reduce(


### PR DESCRIPTION
This issue affected the execution of exercise in `graph/20`  when debugging in Web UI.

Fix is so obvious after checking the code in `lib/graphExercise/graphExerciseTestCase.ts` .

https://github.com/henriqueinonhe/promises-training/blob/bcff2e3bfac6857d81c83fec8ee2653f9a2a79ef/src/lib/graphExercise/graphExerciseTestCase.ts#L163-L167

By the way, it might be impossible to create a `promise('F')` which requires a rejected `promise('D')` and a resolved `promise('E')` at the same time. Since the result from `promise('A')` would lead the story to 2 different branches.

```ts
// before, seems impossible
{
    label: "F",
    dependencies: [["!D", "E"]],
},

// after
{
    label: "F",
    dependencies: [["!D"], ["E"]],
},
```